### PR TITLE
replace `torch.multiprocessing` with `multiprocess`

### DIFF
--- a/parallelformers/parallelize.py
+++ b/parallelformers/parallelize.py
@@ -19,7 +19,8 @@ from dataclasses import _is_dataclass_instance
 from typing import Any, Dict
 
 import torch
-import torch.multiprocessing as mp
+# import torch.multiprocessing as mp
+import multiprocess as mp
 from dacite import Config, from_dict
 from torch import nn
 from transformers.file_utils import ModelOutput


### PR DESCRIPTION
## Title

- replace `torch.multiprocessing` with `multiprocess`

## Description

- `spawn` in `multiprocessing` and `torch,multiprocessing` is not properly handled by IPython, which is the backend for popular Jupyter. Fixed by replacing `torch.multiprocessing` with `multiprocess` in `parallelformers/parallelize.py`

## Linked Issues

- resolved #20